### PR TITLE
fixed: not using override is now deprecated

### DIFF
--- a/orange/xml/PhobosXml.d
+++ b/orange/xml/PhobosXml.d
@@ -149,12 +149,12 @@ final class Attribute : Element
 		parent_ = parent;
 	}
 
-	tstring name ()
+	override tstring name ()
 	{
 		return name_;
 	}
 
-	tstring value ()
+	override tstring value ()
 	{
 		return value_;
 	}


### PR DESCRIPTION
compiling with latest dmd from github throws these errors:

orange/xml/PhobosXml.d(152): Deprecation: overriding base class function without using override attribute is deprecated (orange.xml.PhobosXml.Attribute.name overrides orange.xml.PhobosXml.Element.name)
orange/xml/PhobosXml.d(157): Deprecation: overriding base class function without using override attribute is deprecated (orange.xml.PhobosXml.Attribute.value overrides orange.xml.PhobosXml.Element.value)

adding override fixes this.
