### PR TITLE
-Fix for DMD 2.064 compilation error:  "typecons.d(389): Error: this for...

### DIFF
--- a/orange/util/Use.d
+++ b/orange/util/Use.d
@@ -75,7 +75,7 @@ struct Use (ARGS...)
 	{
 		assert(args[0]);
 
-		static if (NEW_ARGS.length == 1)
+		static if (args.length == 1)
 			return args[0](dg);
 
 		else


### PR DESCRIPTION
... _expand_field_0 needs to be type Tuple not type Use!(void delegate())".

The error was produced by compiling orange with latest DMD in windows. (Both by compiling unitests and by 'dsss build').

After fixing this error, all the unit tests pass with DMD 2.064.

The error is produced when trying to get .length off of NEW_ARGS (and not in the following lines where an args.expand is, that line works fine).

--jm
