### PR TITLE
Fix problem with current LDC2 - init member is now called m_init

### DIFF
--- a/orange/util/Reflection.d
+++ b/orange/util/Reflection.d
@@ -168,8 +168,13 @@ Object newInstance (in ClassInfo classInfo)
     version (LDC)
     {
         Object object = _d_allocclass(classInfo);
-        (cast(byte*) object)[0 .. classInfo.init.length] = classInfo.init[];
-
+        const(void)[]defInitializer = classInfo.initializer();
+        if ((defInitializer !is null) && (defInitializer.length > 0)) {
+            if (defInitializer.ptr !is null)
+                (cast(byte*) object)[0..defInitializer.length] = (cast(byte*)defInitializer.ptr)[0..defInitializer.length];
+            else
+                (cast(byte*) object)[0..defInitializer.length] = 0;
+        }
         return object;
     }
 


### PR DESCRIPTION
The previous 'init' member is of type void now. The code is now testing
for the new member, and uses it to copy init bytes to a new object.

If no member is found, the old behaviour is assumed.